### PR TITLE
Upgrade to latest polkadot release

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
 
-FROM parity/polkadot:v0.6.17
+FROM parity/polkadot:v0.8.26-1
 
 ENTRYPOINT polkadot $EXTRA_OPTS

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,30 +1,10 @@
 {
   "name": "polkadot.public.dappnode.eth",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "DAppNode package for polkadot",
-  "avatar": "/ipfs/QmW7C2BGFmPgsycu6x54gzn21nxGySytmLyVk5qE2BFiDx",
   "type": "library",
-  "image": {
-    "path": "polkadot.public.dappnode.eth_1.2.7.tar.xz",
-    "hash": "/ipfs/QmePt3v6VHVqm2gQUi2ix1Yq4ByLWDrjBC8tyVwbArLmpk",
-    "size": 29141236,
-    "restart": "always",
-    "volumes": [
-      "polkadot:/polkadot"
-    ],
-    "ports": [
-      "30333:30333",
-      "9933:9933",
-      "9944:9944"
-    ],
-    "environment": [
-      "EXTRA_OPTS=--name DAppNodeNodler"
-    ]
-  },
   "author": "francois branciard (francoisbranciard@protonmail.com)",
-  "keywords": [
-    "polkadot"
-  ],
+  "keywords": ["polkadot"],
   "homepage": {
     "homepage": "https://github.com/branciard/DAppNodePackage-polkadot#readme"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
-version: '3.4'
+version: "3.4"
 services:
   polkadot.public.dappnode.eth:
-    image: 'polkadot.public.dappnode.eth:1.2.7'
+    image: "polkadot.public.dappnode.eth:1.3.0"
     build: ./build
     volumes:
-      - 'polkadot:/polkadot'
+      - "polkadot:/polkadot"
     environment:
       - EXTRA_OPTS=--name DAppNodeNodler
     ports:
-      - '30333:30333'
-      - '9933:9933'
-      - '9944:9944'
+      - "30333:30333"
+      - "9933:9933"
+      - "9944:9944"
 volumes:
   polkadot: {}


### PR DESCRIPTION
I found my node unable to find any peers, I assume it was related to the outdated polkadot version. This uses the latest release (0.8.26-1) and fixes some issues with how data is stored in DNPs.